### PR TITLE
Use strip_prefix to remove parent directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,12 @@ fn get_dir_listing(path_buf: &std::path::PathBuf) -> Vec<std::path::PathBuf> {
 
     // remove the parent directory from the paths, so the diffs don't show everything as different
     for maybe_path in maybe_paths {
-        // TODO: use strip_prefix instead (see issue #1)
-        let path: std::path::PathBuf = maybe_path.unwrap().components().skip(1).collect();
+        let path = maybe_path
+            .unwrap()
+            .strip_prefix(path_buf)
+            .unwrap()
+            .to_path_buf();
+
         paths.push(path);
     }
 


### PR DESCRIPTION
This fixes #1 by using strip\_prefix method on PathBuf instead of skipping just the first directory, since the path to the directory could contain a tree of directories.
