### PR TITLE
Remove newline in dir listing string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dirdiff"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirdiff"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,10 +72,12 @@ fn dir_listing_to_string(dir_listing: &Vec<std::path::PathBuf>) -> String {
 
     let mut string = String::new();
 
-    // put each path on a new line
-    for path in dir_listing {
-        string.push_str(path.to_str().unwrap());
+    // put each path on a new line, making sure there is no trailing "\n" at the end
+    string.push_str(dir_listing[0].to_str().unwrap());
+
+    for i in 1..dir_listing.len() {
         string.push_str("\n");
+        string.push_str(dir_listing[i].to_str().unwrap());
     }
 
     string


### PR DESCRIPTION
A newline ("\n") at the end of the dir listing string caused an extra similarity in the diff
