### PR TITLE
Add option to compare file content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,18 +76,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "dirdiff"
 version = "0.3.0"
 dependencies = [
  "clap",
  "colored",
- "diff",
  "glob",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.2.16", features = ["derive"] }
 colored = "2.0.0"
-diff = "0.1.13"
 glob = "0.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ fn get_dir_diff(
 
             target_index += 1;
         } else {
-            // the file paths are equal (relative to the parent directory)
+            // the source and target file paths are equal (relative to the parent directory)
 
             let source_file_path: std::path::PathBuf =
                 [source_dir, &source_dir_listing[source_index]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ struct CliArgs {
     #[clap(parse(from_os_str))]
     target_dir: std::path::PathBuf,
     #[clap(short, long)]
-    quiet: bool,
+    quiet: bool, // don't show similarities (and changed/unchanged files if -f option is given)
     #[clap(short, long)]
     depth: Option<u8>,
     #[clap(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,28 @@ struct CliArgs {
     no_color: bool,
 }
 
+fn check_cli_args(args: &CliArgs) -> Result<(), Box<dyn std::error::Error>> {
+    // check if paths exist
+    if !args.source_dir.exists() {
+        return Err(format!("{} does not exist", args.source_dir.display()).into());
+    }
+
+    if !args.target_dir.exists() {
+        return Err(format!("{} does not exist", args.target_dir.display()).into());
+    }
+
+    // check if paths are directories
+    if !args.source_dir.is_dir() {
+        return Err(format!("{} is not a directory", args.source_dir.display()).into());
+    }
+
+    if !args.target_dir.is_dir() {
+        return Err(format!("{} is not a directory", args.target_dir.display()).into());
+    }
+
+    Ok(())
+}
+
 fn glob_pattern_from_path_buf(path_buf: &std::path::PathBuf, depth: Option<u8>) -> String {
     // Return a glob pattern for every file in a directory (recursively) from a PathBuf, assumed to
     // be a directory
@@ -132,28 +154,6 @@ fn print_diff_summary(dir_diff: &Vec<diff::Result<&str>>, hide_similarities: boo
             num_similar, num_removed, num_added
         );
     }
-}
-
-fn check_cli_args(args: &CliArgs) -> Result<(), Box<dyn std::error::Error>> {
-    // check if paths exist
-    if !args.source_dir.exists() {
-        return Err(format!("{} does not exist", args.source_dir.display()).into());
-    }
-
-    if !args.target_dir.exists() {
-        return Err(format!("{} does not exist", args.target_dir.display()).into());
-    }
-
-    // check if paths are directories
-    if !args.source_dir.is_dir() {
-        return Err(format!("{} is not a directory", args.source_dir.display()).into());
-    }
-
-    if !args.target_dir.is_dir() {
-        return Err(format!("{} is not a directory", args.target_dir.display()).into());
-    }
-
-    Ok(())
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,12 +162,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // error if directories do not exist
     check_cli_args(&args)?;
 
+    // list both directories
     let source_dir_listing = get_dir_listing(&args.source_dir, args.depth);
     let target_dir_listing = get_dir_listing(&args.target_dir, args.depth);
 
+    // get diff
     let source_dir_listing_string = dir_listing_to_string(&source_dir_listing);
     let target_dir_listing_string = dir_listing_to_string(&target_dir_listing);
-
     let dir_diff = diff::lines(&source_dir_listing_string, &target_dir_listing_string);
 
     print_dir_diff(&dir_diff, args.quiet, !args.no_color);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,24 @@ struct CliArgs {
     depth: Option<u8>,
     #[clap(long)]
     no_color: bool,
+    #[clap(short, long)]
+    compare_content: bool,
+}
+
+#[derive(Debug)]
+enum DirDiff<T> {
+    Removed(T), // path is only in source
+    Added(T),   // path is only in target
+
+    Similar(T, Option<DirDiffFileContent>),
+    // path is both source and target; if Option is None, then either the path points to a directory
+    // or file content checking is disabled
+}
+
+#[derive(Debug)]
+enum DirDiffFileContent {
+    Unchanged, // file contents are the same
+    Changed,   // file contents are different
 }
 
 fn check_cli_args(args: &CliArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -91,58 +109,124 @@ fn get_dir_listing(dir_path: &std::path::PathBuf, depth: Option<u8>) -> Vec<std:
     paths
 }
 
-fn dir_listing_to_string(dir_listing: &Vec<std::path::PathBuf>) -> String {
-    // Return the directory listing in string form
+fn get_dir_diff(
+    source_dir_listing: &Vec<std::path::PathBuf>,
+    target_dir_listing: &Vec<std::path::PathBuf>,
+    compare_file_contents: bool,
+) -> Vec<DirDiff<std::path::PathBuf>> {
+    // Return diff between two directories
+    // NOTE: this function assumes both directory listings are sorted by unicode values
 
-    let mut string = String::new();
+    println!("{:?}", source_dir_listing);
+    println!("{:?}", target_dir_listing);
 
-    // put each path on a new line, making sure there is no trailing "\n" at the end
-    string.push_str(dir_listing[0].to_str().unwrap());
+    let longest_listing = std::cmp::max(source_dir_listing.len(), target_dir_listing.len());
 
-    for i in 1..dir_listing.len() {
-        string.push_str("\n");
-        string.push_str(dir_listing[i].to_str().unwrap());
+    // indexes for both vectors
+    let mut source_index = 0;
+    let mut target_index = 0;
+
+    let mut diff_output = Vec::<DirDiff<std::path::PathBuf>>::new();
+
+    // go through both arrays at the same time, to ensure O(n) time
+    for _ in 0..longest_listing {
+        if source_dir_listing[source_index] < target_dir_listing[target_index] {
+            println!(
+                "{:?} comes before {:?}",
+                source_dir_listing[source_index], target_dir_listing[target_index]
+            );
+
+            diff_output.push(DirDiff::Removed(source_dir_listing[source_index].clone()));
+
+            source_index += 1;
+        } else if source_dir_listing[source_index] > target_dir_listing[target_index] {
+            println!(
+                "{:?} comes after {:?}",
+                source_dir_listing[source_index], target_dir_listing[target_index]
+            );
+
+            diff_output.push(DirDiff::Added(target_dir_listing[target_index].clone()));
+
+            target_index += 1;
+        } else {
+            println!(
+                "{:?} is equal to {:?}",
+                source_dir_listing[source_index], target_dir_listing[target_index]
+            );
+
+            // TODO: if file content checking is used, do it here
+            diff_output.push(DirDiff::Similar(
+                source_dir_listing[source_index].clone(),
+                None, // TODO: no file content checking used yet
+            ));
+
+            source_index += 1;
+            target_index += 1;
+        }
+
+        // add the remaining items to the dir diff if it reached the end of one dir listing
+        if source_index >= source_dir_listing.len() {
+            // add the remaining ADDED items of the other dir listing
+            for i in target_index..target_dir_listing.len() {
+                diff_output.push(DirDiff::Added(target_dir_listing[i].clone()));
+            }
+
+            break;
+        } else if target_index >= target_dir_listing.len() {
+            // add the remaining REMOVED items of the other dir listing
+            for i in source_index..source_dir_listing.len() {
+                diff_output.push(DirDiff::Removed(source_dir_listing[i].clone()));
+            }
+
+            break;
+        }
     }
 
-    string
+    diff_output
 }
 
-fn print_dir_diff(dir_diff: &Vec<diff::Result<&str>>, hide_similarities: bool, color: bool) {
+fn print_dir_diff(
+    dir_diff: &Vec<DirDiff<std::path::PathBuf>>,
+    hide_similarities: bool,
+    color: bool,
+) {
     for diff_fragment in dir_diff {
         match diff_fragment {
-            diff::Result::Left(path) => {
+            DirDiff::Removed(path) => {
                 if color {
-                    println!("{} {}", "-".red(), path.red());
+                    println!("{} {}", "-".red(), path.to_str().unwrap().red());
                 } else {
-                    println!("- {}", path);
+                    println!("- {}", path.to_str().unwrap());
                 }
             }
-            diff::Result::Both(path, _) => {
+            DirDiff::Added(path) => {
+                if color {
+                    println!("{} {}", "+".green(), path.to_str().unwrap().green());
+                } else {
+                    println!("+ {}", path.to_str().unwrap());
+                }
+            }
+            DirDiff::Similar(path, _) => {
+                // TODO: print differently if it is similar changed/unchanged
                 if !hide_similarities {
-                    println!(" {}", path);
-                }
-            }
-            diff::Result::Right(path) => {
-                if color {
-                    println!("{} {}", "+".green(), path.green());
-                } else {
-                    println!("+ {}", path);
+                    println!(" {}", path.to_str().unwrap());
                 }
             }
         }
     }
 }
 
-fn print_diff_summary(dir_diff: &Vec<diff::Result<&str>>, hide_similarities: bool) {
+fn print_diff_summary(dir_diff: &Vec<DirDiff<std::path::PathBuf>>, hide_similarities: bool) {
     let mut num_removed = 0;
     let mut num_similar = 0;
     let mut num_added = 0;
 
+    // TODO: count number of similar changed and similar unchanged as well
     for diff_fragment in dir_diff {
         match diff_fragment {
-            diff::Result::Left(_) => num_removed += 1,
-            diff::Result::Both(_, _) => num_similar += 1,
-            diff::Result::Right(_) => num_added += 1,
+            DirDiff::Removed(_) => num_removed += 1,
+            DirDiff::Added(_) => num_added += 1,
+            DirDiff::Similar(_, _) => num_similar += 1,
         }
     }
 
@@ -167,9 +251,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let target_dir_listing = get_dir_listing(&args.target_dir, args.depth);
 
     // get diff
-    let source_dir_listing_string = dir_listing_to_string(&source_dir_listing);
-    let target_dir_listing_string = dir_listing_to_string(&target_dir_listing);
-    let dir_diff = diff::lines(&source_dir_listing_string, &target_dir_listing_string);
+    let dir_diff = get_dir_diff(
+        &source_dir_listing,
+        &target_dir_listing,
+        args.compare_content,
+    );
 
     print_dir_diff(&dir_diff, args.quiet, !args.no_color);
     print_diff_summary(&dir_diff, args.quiet);


### PR DESCRIPTION
Use `--file` or `-f` to also compare file contents.
If two paths are the same but one is a file and one is a directory, it will be considered CHANGED.
If two paths are the same and both are files, but they content is different, it will be CHANGED.
If two paths are the same and are both files, and their content is the same, it will be UNCHANGED.
The way directories are compared is the same (if the two paths are the same, they are SIMILAR).

Resolves #31.
Fixes #33.